### PR TITLE
Change On write

### DIFF
--- a/functions/firestore/activity/on-write.js
+++ b/functions/firestore/activity/on-write.js
@@ -87,7 +87,7 @@ const growthFileMsIntegration = async change => {
 
   return growthfileMsRequester({
     method: msRequestTypes.ACTIVITY,
-    payload:JSON.stringify(activityData),
+    payload: JSON.stringify(activityData),
     resourcePath: msEndpoints.ACTIVITY,
   });
 };
@@ -714,7 +714,14 @@ const handleSubscription = async locals => {
   }
 
   batch.set(subscriptionDocRef, subscriptionDocData, { merge: true });
-
+  batch.set(
+    rootCollections.profiles
+      .doc(newSubscriber)
+      .collection(subcollectionNames.SUBSCRIPTIONS)
+      .doc('template_' + locals.change.after.get('attachment.Template.value')),
+    locals.change.after.data(),
+    { merge: true },
+  );
   const newSubscriberAuth = await getAuth(newSubscriber);
 
   if (newSubscriberAuth.uid) {


### PR DESCRIPTION
This new code stores original subscription too with id template_{templateName}
This naming avoids multiple template store that's why I didn't use auto ids